### PR TITLE
distribute non minified css 📬

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
   "name": "tachyons-egghead",
   "version": "2.1.0",
   "description": "Tachyons packages edited for egghead.io",
-  "main": "css/tachyons.min.css",
+  "main": "css/tachyons.css",
   "scripts": {
     "dev": "watch 'yarn build' ./src/",
-    "build": "mkdir -p css && tachyons src/tachyons.css -m > css/tachyons.min.css",
+    "build": "mkdir -p css && tachyons src/tachyons.css -m > css/tachyons.min.css && tachyons src/tachyons.css > css/tachyons.css",
     "verify": "yarn build",
     "bump": "yarn version && git push && git push --tags",
     "prepublish": "yarn build"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tachyons-egghead",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Tachyons packages edited for egghead.io",
   "main": "css/tachyons.css",
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2644,9 +2644,9 @@ tachyons-borders@^3.0.3:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/tachyons-borders/-/tachyons-borders-3.0.4.tgz#4d52c19ad3bcb7817a5c1078a2eb9dfb0b3dc40f"
 
-tachyons-box-shadow@^2.0.3:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/tachyons-box-shadow/-/tachyons-box-shadow-2.0.4.tgz#a3bf4650efd67cffcfedce2489d8ba522644000c"
+"tachyons-box-shadow@github:eggheadio/tachyons-box-shadow":
+  version "2.1.0"
+  resolved "https://codeload.github.com/eggheadio/tachyons-box-shadow/tar.gz/cb5fb6e0c0d360536e66b2c92909bd36d5939b77"
 
 tachyons-box-sizing@^3.2.0:
   version "3.2.1"


### PR DESCRIPTION
The module pointing at the minified version of the css was problematic for us, so this also adds unminified css and sets that to the main file for the module. This will leave minification concerns to the client/enduser.

![](https://media.giphy.com/media/hFmIU5GQF18Aw/giphy.gif)